### PR TITLE
bazel: Fix the JDK for linux-aarch64

### DIFF
--- a/tools/WORKSPACE
+++ b/tools/WORKSPACE
@@ -190,8 +190,8 @@ remote_java_repository(
         "@platforms//os:linux",
     ],
     urls = [
-        "https://cdn.azul.com/zulu/bin/zulu17.42.19-ca-jdk17.0.7-macosx_aarch64.tar.gz",
-        "https://sonatype-nexus.it-fivetran.com/repository/azul/zulu/bin/zulu17.42.19-ca-jdk17.0.7-macosx_aarch64.tar.gz",
+        "https://cdn.azul.com/zulu/bin/zulu17.42.19-ca-jdk17.0.7-linux_aarch64.tar.gz",
+        "https://sonatype-nexus.it-fivetran.com/repository/azul/zulu/bin/zulu17.42.19-ca-jdk17.0.7-linux_aarch64.tar.gz",
     ],
     version = "17",
 )


### PR DESCRIPTION
The `WORKSPACE` file had the wrong URLs defined for downloading the Java toolchain for linux-aarch64, this PR updates the URLs to be correct.

Note: starting to rely on Bazel for part of our testing, makes me think we should have our own mirror where we can host these assets.